### PR TITLE
Fix UIButton highlight behaviour when contained by MessagesCollectionView

### DIFF
--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -71,7 +71,6 @@ open class MessagesCollectionView: UICollectionView {
     
     private func setupGestureRecognizers() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTapGesture(_:)))
-        tapGesture.delaysTouchesBegan = true
         addGestureRecognizer(tapGesture)
     }
     


### PR DESCRIPTION
remove delay of tap gesture recognizer, allowing buttons in message cells to react to touch down events and hilight properly

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Because the tap gesture recognizer on `MessagesCollectionView` delays the touch began events, `UIButton` subviews can't properly respond by highlighting.
I didn't see a good reason for `delaysTouchesBegan` to be on so I removed it.

Does this close any currently open issues?
------------------------------------------
nope


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


