### PR TITLE
Respect paragraph styles of attributed string in MessageLabel

### DIFF
--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -213,11 +213,14 @@ open class MessageLabel: UILabel {
             return
         }
         
-        let style = paragraphStyle(for: newText)
         let range = NSRange(location: 0, length: newText.length)
-        
         let mutableText = NSMutableAttributedString(attributedString: newText)
-        mutableText.addAttribute(.paragraphStyle, value: style, range: range)
+        (mutableText.string as NSString).enumerateSubstrings(in: range, options: .byParagraphs) { (_, paragraphRange, _, _) in
+            let style = mutableText.attribute(.paragraphStyle, at: paragraphRange.location, effectiveRange: nil) as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            style.lineBreakMode = self.lineBreakMode
+            style.alignment = self.textAlignment
+            mutableText.addAttribute(.paragraphStyle, value: style, range: paragraphRange)
+        }
         
         if shouldParse {
             rangesForDetectors.removeAll()
@@ -239,19 +242,6 @@ open class MessageLabel: UILabel {
 
         if !isConfiguring { setNeedsDisplay() }
 
-    }
-    
-    private func paragraphStyle(for text: NSAttributedString) -> NSParagraphStyle {
-        guard text.length > 0 else { return NSParagraphStyle() }
-        
-        var range = NSRange(location: 0, length: text.length)
-        let existingStyle = text.attribute(.paragraphStyle, at: 0, effectiveRange: &range) as? NSMutableParagraphStyle
-        let style = existingStyle ?? NSMutableParagraphStyle()
-        
-        style.lineBreakMode = lineBreakMode
-        style.alignment = textAlignment
-        
-        return style
     }
 
     private func updateAttributes(for detectors: [DetectorType]) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When using a `MessageLabel`, using multiple paragraph styles within the attributed string wasn't supported, they were overwritten with the first paragraph's style. This caused a discrepancy between the size computed by `MessageSizeCalculator` and the actual size needed for rendering within `MessageLabel` causing messages to get cut in some scenarios.

The solution is to iterate through each paragraph and update their corresponding style by only mutating the properties we care about: line breaking and text alignment.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**MessageKit Version:** …


